### PR TITLE
Ensure Initialization of MythicDungeonPortalsSettings in addon:OnInitialize

### DIFF
--- a/Minimap/Minimap.lua
+++ b/Minimap/Minimap.lua
@@ -31,12 +31,15 @@ local mythicDungeonPortalsLDB = LibStub("LibDataBroker-1.1"):NewDataObject("Myth
 addon.icon = LibStub("LibDBIcon-1.0")
 
 function addon:OnInitialize()
+	if not MythicDungeonPortalsSettings then
+		MythicDungeonPortalsSettings = {}
+	end
 	self.db = LibStub("AceDB-3.0"):New("MythicDungeonPortalsMinimap", {
 		profile = {
-			minimap = {
-				hide = not MythicDungeonPortalsSettings.isMinimapEnabled,
-			},
-		},
-	})
-	addon.icon:Register("MythicDungeonPortals", mythicDungeonPortalsLDB, self.db.profile.minimap)
+            		minimap = {
+                		hide = not MythicDungeonPortalsSettings.isMinimapEnabled,
+           		},
+        	},
+    	})
+    	addon.icon:Register("MythicDungeonPortals", mythicDungeonPortalsLDB, self.db.profile.minimap)
 end


### PR DESCRIPTION
Issue: Encountered a nil value error when accessing MythicDungeonPortalsSettings.isMinimapEnabled in addon:OnInitialize. This issue arises due to MythicDungeonPortalsSettings not being initialized before its first use in some cases, particularly when the ADDON_LOADED event that triggers LoadDefaultSettings has not been processed yet.

Solution: Added a safety check in the addon:OnInitialize method to ensure MythicDungeonPortalsSettings is initialized as an empty table if it does not already exist. This prevents the nil value error and ensures stable functionality of the addon, even if LoadDefaultSettings has not yet run.

Rationale: This change ensures that the addon does not fail due to uninitialized settings, improving reliability. It also maintains the modular design of the addon by ensuring that default settings are handled within their respective initialization contexts.